### PR TITLE
Исправлен баг с сохранением в локальную базу несколько отправленных сообщений

### DIFF
--- a/lib/modules/signal_service/bloc/chat_bloc/chat_bloc.dart
+++ b/lib/modules/signal_service/bloc/chat_bloc/chat_bloc.dart
@@ -53,6 +53,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     listEquals(chats, restChats)
         ? emit(state.copyWith(chats: restChats))
         : emit(state.copyWith(chats: chats));
+    print("ListEquals: ${listEquals(chats, restChats)}");
 
     //если локальная база отличается от серверной,
     //то перезаписываем локальную базу

--- a/lib/modules/signal_service/bloc/user_bloc/user_bloc.dart
+++ b/lib/modules/signal_service/bloc/user_bloc/user_bloc.dart
@@ -30,19 +30,30 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     _mainUserServices = MainUserServices();
     _messagesServices = LocalMessagesServices();
     _chatServices = LocalChatServices();
+
     DBHelper.instanse.updateListenController.stream.listen((event) async {
       if (event == true) {
-        var users = await _usersServices.getAllUsers();
-        print('sort message:$users');
-        add(ReadUsersEvent(users: users));
-        // state.copyWith(messages: messages);
+        add(LocalReadUsersEvent());
       }
     });
+    
     on<ReadUsersEvent>(_onReadUsersEvent);
     on<CreateUserEvent>(_onCreateUserEvent);
     on<ChangeUserEvent>(_onChangeUserEvent);
     on<UpdateUserEvent>(_onUpdateUserEvent);
     on<DeleteUserEvent>(_onDeleleUserEvent);
+    on<LocalReadUsersEvent>(_onLocalReadUsersEvent);
+  }
+
+  FutureOr<void> _onLocalReadUsersEvent(
+      LocalReadUsersEvent event, Emitter<UserState> emit) async {
+    var users = <UserDto>[];
+    users = await _usersServices.getAllUsers();
+    for (var userServ in users) {
+      print('USERS BLOCK: $userServ');
+    }
+    //Добавляем всех юзеров в state
+    emit(state.copyWith(users: users));
   }
 
   FutureOr<void> _onReadUsersEvent(

--- a/lib/modules/signal_service/bloc/user_bloc/user_event.dart
+++ b/lib/modules/signal_service/bloc/user_bloc/user_event.dart
@@ -15,6 +15,11 @@ class CreateUserEvent extends UserEvent {
   List<Object?> get props => [user];
 }
 
+class LocalReadUsersEvent extends UserEvent {
+  @override
+  List<Object?> get props => [];
+}
+
 class ReadUsersEvent extends UserEvent {
   final List<UserDto>? users;
   final bool userDb;


### PR DESCRIPTION
Добавлен event в юзер блок, которые выполняется при изменениях в базе.
Просто читает из локальной базы юзеров и закидывает в state.
Ошибка была в том, что ранее вызывался метод readUsersEvent, который является синхронизацией. Синхронизация проходила быстрее чем приходил ответ от сервера с messageId для отправленного сообщения.